### PR TITLE
misha entry: remove malto link and fix google scholar link

### DIFF
--- a/content/authors/Misha Lvovsky/_index.md
+++ b/content/authors/Misha Lvovsky/_index.md
@@ -44,12 +44,9 @@ education:
 #   form "mailto:your-email@example.com" or "#contact" for contact widget.
 
 social:
-- icon: envelope
-  icon_pack: fas
-  link: 'mailto:lvovsky.m@northeastern.edu'
 - icon: google-scholar
   icon_pack: ai
-  link: https://scholar.google.com/citations?user=Igre_ZoAAAAJ&hl=en
+  link: https://scholar.google.com/citations?hl=en&user=0yQFixIAAAAJ
 - icon: github
   icon_pack: fab
   link: https://github.com/mishmish66


### PR DESCRIPTION
I just wanted to remove the mailto link to avoid spam and fixed the google scholar link to point to mine